### PR TITLE
CDMS-856: simulates requests to Decision Comparer and provides OK or Conflict response

### DIFF
--- a/BtmsGatewayStub/Middleware/StubInterceptor.cs
+++ b/BtmsGatewayStub/Middleware/StubInterceptor.cs
@@ -61,7 +61,7 @@ public class StubInterceptor(RequestDelegate next, ILogger logger)
         }
     }
 
-    private string GetContent(string? contentType)
+    private static string GetContent(string? contentType)
     {
         if (string.IsNullOrEmpty(contentType))
             return string.Empty;
@@ -79,7 +79,7 @@ public class StubInterceptor(RequestDelegate next, ILogger logger)
         return string.Empty;
     }
 
-    private bool IsDecisionComparerConflictRequest(HttpContext context)
+    private static bool IsDecisionComparerConflictRequest(HttpContext context)
     {
         return context.Request.Path.HasValue && (context.Request.Path.Value.StartsWith("/409/btms-decisions/") ||
                                                  context.Request.Path.Value.StartsWith("/409/alvs-decisions/") ||
@@ -87,7 +87,7 @@ public class StubInterceptor(RequestDelegate next, ILogger logger)
                                                  context.Request.Path.Value.StartsWith("/409/alvs-outbound-errors/"));
     }
 
-    private bool IsDecisionComparerSuccessRequest(HttpContext context)
+    private static bool IsDecisionComparerSuccessRequest(HttpContext context)
     {
         return context.Request.Path.HasValue && (context.Request.Path.Value.StartsWith("/btms-decisions/") ||
                                                  context.Request.Path.Value.StartsWith("/alvs-decisions/") ||


### PR DESCRIPTION
- Checks for Decision Comparer requests and responds with either a 409 Conflict or an OK response
- Returns back the original Decision/Error Notification in the response body if it's an OK response otherwise and empty body for 409 Conflict response
- Allows for testing of Gateway functionality by configuring it to point Decision Comparer requests at the Stub instead of the Decision Comparer API